### PR TITLE
Refactor User Management to Organization-Centric Architecture

### DIFF
--- a/alembic/versions/94d74fb48263_022_fix_invites_references.py
+++ b/alembic/versions/94d74fb48263_022_fix_invites_references.py
@@ -1,0 +1,66 @@
+"""022_fix_invites_references
+
+Revision ID: 94d74fb48263
+Revises: 3c4d5e6f7g8h
+Create Date: 2025-09-03 01:25:18.630638
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "94d74fb48263"
+down_revision: Union[str, None] = "3c4d5e6f7g8h"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+  # Make stytch_id nullable to support pre-creation of invited users
+  op.alter_column("users", "stytch_id", nullable=True)
+
+  # Add invite_id column to organization_members table to track invitation used for org membership
+  op.add_column("organization_members", sa.Column("invite_id", sa.UUID(), nullable=True))
+
+  # Add deleted_by column to track who deleted the user from the organization
+  op.add_column("organization_members", sa.Column("deleted_by", sa.UUID(), nullable=True))
+
+  # Create foreign key constraints
+  op.create_foreign_key("fk_org_members_invite_id", "organization_members", "invites", ["invite_id"], ["id"], ondelete="SET NULL")
+  op.create_foreign_key("fk_org_members_deleted_by", "organization_members", "users", ["deleted_by"], ["id"], ondelete="SET NULL")
+
+  # Add indexes for better query performance
+  op.create_index("ix_org_members_invite_id", "organization_members", ["invite_id"])
+  op.create_index("ix_org_members_deleted_by", "organization_members", ["deleted_by"])
+
+  # Add "deleted" to member_status enum (only if it doesn't exist)
+  op.execute(
+    "DO $$ BEGIN "
+    "IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'deleted' AND "
+    "enumtypid = (SELECT oid FROM pg_type WHERE typname = 'member_status')) "
+    "THEN ALTER TYPE member_status ADD VALUE 'deleted'; END IF; END $$"
+  )
+
+  # Drop the invited_by column from invites table since we track this in organization_members
+  op.drop_column("invites", "invited_by")
+
+
+def downgrade() -> None:
+  # Re-add invited_by column to invites table
+  op.add_column("invites", sa.Column("invited_by", sa.UUID(), nullable=True))
+
+  # Drop indexes
+  op.drop_index("ix_org_members_deleted_by", table_name="organization_members")
+  op.drop_index("ix_org_members_invite_id", table_name="organization_members")
+
+  # Drop foreign key constraints
+  op.drop_constraint("fk_org_members_deleted_by", "organization_members", type_="foreignkey")
+  op.drop_constraint("fk_org_members_invite_id", "organization_members", type_="foreignkey")
+
+  # Drop columns
+  op.drop_column("organization_members", "deleted_by")
+  op.drop_column("organization_members", "invite_id")

--- a/src/libs/stytch/v1/base.py
+++ b/src/libs/stytch/v1/base.py
@@ -70,18 +70,21 @@ class StytchBase:
     email: str,
     first_name: str | None = None,
     last_name: str | None = None,
-    invitation_id: str | None = None,
-    organization_id: str | None = None,
-    role_id: str | None = None,
+    external_user_id: str | None = None,
   ) -> LibResponse[InviteResponse] | LibResponse[None]:
     """Invite user with organization context for webhook processing."""
     try:
       name = Name(first_name=first_name, last_name=last_name)
 
-      # Include invitation context in untrusted_metadata
-      invitation_context = {"type": "invitation", "invitation_id": invitation_id, "organization_id": organization_id, "role_id": role_id}
+      # Include minimal trusted metadata (secure)
+      trusted_metadata = {"external_user_id": external_user_id, "is_invited": True}
 
-      response = await self.client.magic_links.email.invite_async(email, name=name, untrusted_metadata=invitation_context)
+      # Include type in untrusted_metadata for webhook processing
+      untrusted_metadata = {"type": "invitation"}
+
+      response = await self.client.magic_links.email.invite_async(
+        email, name=name, trusted_metadata=trusted_metadata, untrusted_metadata=untrusted_metadata
+      )
       return LibResponse.success_response(response)
     except Exception as e:
       return LibResponse.error_response([{"message": str(e)}])

--- a/src/models/auth_model.py
+++ b/src/models/auth_model.py
@@ -1,6 +1,6 @@
 from sqlalchemy import String
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from database import CRUD
 
@@ -10,15 +10,12 @@ class UserModel(CRUD):
 
   __tablename__ = "users"
 
-  stytch_id: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
+  stytch_id: Mapped[str | None] = mapped_column(String(255), nullable=True, unique=True, index=True)
   email: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
   password: Mapped[str] = mapped_column(String(64), nullable=True)
   first_name: Mapped[str] = mapped_column(String(50), nullable=True)
   last_name: Mapped[str] = mapped_column(String(50), nullable=True)
   _metadata: Mapped[dict] = mapped_column("metadata", JSONB, nullable=True)
-
-  # Relationships
-  sent_invitations = relationship("InvitationModel", foreign_keys="InvitationModel.invited_by", back_populates="inviter")
 
   @property
   def full_name(self) -> str:

--- a/src/models/invitations_model.py
+++ b/src/models/invitations_model.py
@@ -29,14 +29,12 @@ class InvitationModel(CRUD):
   organization_id: Mapped[UUID] = mapped_column(PGUUID, ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False)
   role_id: Mapped[UUID] = mapped_column(PGUUID, ForeignKey("roles.id", ondelete="CASCADE"), nullable=False)
   invitee_email: Mapped[str] = mapped_column(String(255), nullable=False)
-  invited_by: Mapped[UUID] = mapped_column(PGUUID, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
   status: Mapped[int] = mapped_column(SmallInteger, nullable=False, default=InvitationStatus.PENDING)
   expiry_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
   # Relationships
   organization = relationship("OrganizationModel", back_populates="invitations")
   role = relationship("RoleModel", back_populates="invitations")
-  inviter = relationship("UserModel", foreign_keys=[invited_by], back_populates="sent_invitations")
 
   def __repr__(self) -> str:
     return f"<InvitationModel(id={self.id}, email={self.invitee_email}, status={self.status})>"

--- a/src/services/users/schema.py
+++ b/src/services/users/schema.py
@@ -59,14 +59,15 @@ class InviteSignup(BaseModel):
 class InviteResponse(BaseModel):
   """Invite response schema."""
 
-  id: Optional[str] = None
+  id: str
   email: EmailStr
   first_name: str = ""
   last_name: str = ""
   full_name: str = ""
-  invite_id: str
-  organizations: list[dict]
+  organizations: OrganizationInfo
 
+  class Config:
+    from_attributes = True
 
 class StytchUser(BaseModel):
   """Stytch user schema."""

--- a/src/services/users/schema.py
+++ b/src/services/users/schema.py
@@ -69,6 +69,7 @@ class InviteResponse(BaseModel):
   class Config:
     from_attributes = True
 
+
 class StytchUser(BaseModel):
   """Stytch user schema."""
 


### PR DESCRIPTION
## Refactored user invitation and management system to be organization-centric instead of user-centric. This provides better multi-tenancy support and cleaner separation of concerns.

### Database Schema
- **UserModel:** Removed `is_deleted`, `invited_by`, `invite_id`, `is_active` columns
- **UserModel:** Made `stytch_id` nullable for invited users
- **OrganizationMemberModel:** Added `invite_id` and `deleted_by` columns
- **OrganizationMemberModel:** Added `"deleted"` to status enum
- **InvitationModel:** Removed `invited_by` column

### Invitation Flow
- **Before:** Create invitation → User signs up → Link to organization
- **After:** Create user + organization member (invited status) → User accepts → Activate membership

### User Deletion
- **Before:** Global user deletion (`user.is_deleted = True`)
- **After:** Organization-specific removal (`org_member.status = "deleted"`)

### Security Updates
- Updated RBAC and APIKeyAuth to check organization member status
- Added specific error messages for different member states

### API Changes
- **POST /api/users/invite**: Now creates user immediately with invited status
- **DELETE /api/users/{id}**: Now organization-scoped deletion
- **POST /api/auth** (webhook): Enhanced to handle pre-created users